### PR TITLE
Added AuthStateUserObject to infer returned object by useAuthUser and withAuthUser

### DIFF
--- a/src/higherOrderComponents/withAuthUser.tsx
+++ b/src/higherOrderComponents/withAuthUser.tsx
@@ -6,12 +6,13 @@
   */
 import * as React from 'react';
 import {AuthContextConsumer} from '../AuthProvider';
+import {AuthStateUserObject} from '../types';
 
 /**
  * @interface withAuthProps
  */
 interface withAuthProps {
-    authState: object | null
+    authState: AuthStateUserObject| null
 }
 
 /**

--- a/src/hooks/useAuthUser.ts
+++ b/src/hooks/useAuthUser.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import {AuthContext} from '../AuthProvider';
+import {AuthStateUserObject} from '../types';
 
 /**
  * Auth State Hook
  *
  * @returns - Auth State Function
  */
-function useAuthUser(): () => object | null {
+function useAuthUser(): () => AuthStateUserObject | null {
   const c = React.useContext(AuthContext);
 
   return () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,14 +7,14 @@ export interface TokenInterface {
   isUsingRefreshToken: boolean
   refreshToken: string | null
   refreshTokenExpireAt: Date | null
-  authState: object | null
+  authState: AuthStateUserObject | null
 }
 
 export interface signInFunctionParams {
   token: string
   tokenType: string | 'Bearer'
   expiresIn: number
-  authState: object
+  authState: AuthStateUserObject
   refreshToken?: string
   refreshTokenExpireIn?: number
 }
@@ -41,4 +41,8 @@ export interface AuthProviderProps {
   cookieDomain?: string
   cookieSecure?: boolean
   children: React.ReactNode
+}
+
+export type AuthStateUserObject = {
+  [x: string]: any;
 }


### PR DESCRIPTION
As per the title, I've added the object below. 

```javascript
export type AuthStateUserObject = {
  [x: string]: any;
}
```

On the current version, the `useAuthUser()` and `withAuthUser()` functions are using `object` to infer the possible returned value of the return function inside, which is producing this typescript problem: `Property 'user' does not exist on type 'object'` when accessing properties of the object returned by `useAuthUser()` and/or `withAuthUser()`. 

The type I've added would tell typescript and/or the code editor that it can expect the returned object to have a property or have properties with a key and a value. If there's a better way to implement this then please do so. I only tried to address an issue I faced while using the plugin. 

Tested on: Typescript 4.2.3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
