### PR TITLE
Calling a function because authHeader is a function.

### DIFF
--- a/docs/authheader.md
+++ b/docs/authheader.md
@@ -30,7 +30,7 @@ const SomeComponent = () => {
 
     return(
         <div>
-            {authHeader}
+            {authHeader()}
         </div>
     )
 }
@@ -52,7 +52,7 @@ class SomeComponent extends React.Component {
     render(){
         return (
             <div>
-                {this.props.authHeader}
+                {this.props.authHeader()}
             </div>
         )
     }


### PR DESCRIPTION
Found an error in the documentation. In the template, the `authHeader` variable is a reference to a function, so nothing is displayed on the screen. You need to call the function to see the result.