### PR TITLE
Bug Fix for Missing `throw`

### DIFF
--- a/packages/react-auth-kit/src/RxTokenObject.ts
+++ b/packages/react-auth-kit/src/RxTokenObject.ts
@@ -270,7 +270,7 @@ class TokenObject<T> {
             isSignIn: false,
             userState: null,
           };
-          new AuthError('Given Auth Token is already expired.');
+          throw new AuthError('Given Auth Token is already expired.');
         }
       } catch (e) {
         obj = {
@@ -279,7 +279,7 @@ class TokenObject<T> {
           isSignIn: false,
           userState: null,
         };
-        new AuthError(
+        throw new AuthError(
             'Error pursing the Auth Token. Make sure you provided a valid JWT.',
         );
       }
@@ -319,7 +319,7 @@ class TokenObject<T> {
               userState: null,
               refresh: null,
             };
-            new AuthError('Given Refresh Token is already expired.');
+            throw new AuthError('Given Refresh Token is already expired.');
           }
         } catch (e) {
           obj = {
@@ -329,7 +329,7 @@ class TokenObject<T> {
             userState: null,
             refresh: null,
           };
-          new AuthError(
+          throw new AuthError(
               'Error pursing the Auth Token.'+
               ' Make sure you provided a valid JWT.',
           );


### PR DESCRIPTION
# 🛠️ Pull Request: Bug Fix for Missing `throw`

## 🧩 Types of Changes  
- ✅ Bug fix (non-breaking change which fixes an issue)

---

## 📝 Description  

This PR addresses a bug while setting the context while signing in in `react-auth-kit`.  
The method currently lacks `throw` statements when sign-in fails, which causes it to incorrectly return `true` in some failure scenarios.

### ✅ What’s Fixed
- Added missing `throw` statements to ensure the failure state is properly handled.

---

## ✅ Tests Added?  
- [ ] Yes  
- [x] No, because they aren't needed for this change

---

## 📚 Documentation Updates  
- [ ] README  
- [ ] Additional Documentation  
- [x] No documentation changes needed

---

## ✔️ Checklist  
- [x] Code follows the style guidelines of this project  
- [x] I have reviewed my own code  
- [x] I have commented in hard-to-understand areas  
- [x] No new warnings introduced  

---

